### PR TITLE
randomize wait time before killing second node in pairkill scenario

### DIFF
--- a/reefer/scripts/k3d-fault-driver.js
+++ b/reefer/scripts/k3d-fault-driver.js
@@ -67,7 +67,8 @@ async function doit(sleep) {
       while ( node2 == node ) {
         node2 = rndnode();
       }
-      await new Promise(resolve => setTimeout(resolve, (13 * 1000)));
+      pairTime = 10 + Math.trunc(10 * Math.random());
+      await new Promise(resolve => setTimeout(resolve, (pairTime * 1000)));
       timestamp = new Date().toLocaleString('en-US', { hour12: false });
       console.log(timestamp+' k3d node '+action+' '+node2);
       doitx = spawnSync('/usr/local/bin/k3d',['node',action,node2]);


### PR DESCRIPTION
Wait for a random 10-20 seconds before killing the second node in the pair kill scenario.  This means we might occasionally wait too long, but is a better stress test since it will spread the second failure through different stages of the reconciliation phase of recovery.
